### PR TITLE
Makefile and README updates, help with MacOS X on latest Lion/homebrew

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,10 +10,16 @@
 
 all: DASSL DASPK DASKR cython
 
-cython:
+REQUIRED = dassl/daux.o dassl/ddassl.o dassl/dlinpk.o
+
+$(REQUIRED): DASSL
+	
+
+cython: $(REQUIRED) pydas.pyx
 	python setup.py build_ext $(CYTHON_FLAGS)
 
-install:
+
+install: $(REQUIRED) cython
 	python setup.py install
 
 DASSL:
@@ -26,6 +32,7 @@ DASKR:
 	$(MAKE) -C daskr F77=$(F77)
 
 clean: clean-DASSL clean-DASPK clean-DASKR clean-cython
+	rm -rf build
 
 clean-DASSL:
 	$(MAKE) -C dassl clean

--- a/README.rst
+++ b/README.rst
@@ -106,17 +106,25 @@ the Makefiles (e.g. the Fortran compiler). An example of such a file,
 `make.inc.example`, has been provided.
 
 
-Mac OS X Lion
--------------
+Mac OS X
+--------
 
 Homebrew (http://mxcl.github.com/homebrew/) is an easy way to get gfortran::
 
     $ brew install gfortran
 
-But your system may still not be able to find the correct `libgfortran.a` library file 
+But your system may still not be able to find the correct `libgfortran.a` library file
 (see https://github.com/mxcl/homebrew/issues/8539 ). Also, there are some problems
 linking with `clang`, so you need to make it link with `gcc`. This one-liner should
-build and install, assuming you have numpy, cython, etc. all set up::
+build and install, assuming you have NumPy, Cython, etc. all set up::
 
-    $ LIBRARY_PATH=/usr/local/lib/gcc LDSHARED='gcc -bundle -undefined dynamic_lookup -arch x86_64' make F77=gfortran install 
+    $ LIBRARY_PATH=/usr/local/lib/gcc LDSHARED='gcc -bundle -undefined dynamic_lookup -arch x86_64' make F77=gfortran install
+
+Or perhaps, with a newer version of Homebrew / Python / gfortran / NumPy / Cython, it will be a simple::
+
+    $ LIBRARY_PATH=/usr/local/Cellar/gfortran/4.8.0/gfortran/lib make F77=gfortran
+
+It seems to keep on changing. If you have difficulty, check the
+`issue tracker <https://github.com/jwallen/PyDAS/issues/>`_, and if you solve
+your difficulty, please share your successful approach.
 

--- a/README.rst
+++ b/README.rst
@@ -114,10 +114,9 @@ Homebrew (http://mxcl.github.com/homebrew/) is an easy way to get gfortran::
     $ brew install gfortran
 
 But your system may still not be able to find the correct `libgfortran.a` library file 
-(see https://github.com/mxcl/homebrew/issues/8539 ). This should make it work::
+(see https://github.com/mxcl/homebrew/issues/8539 ). Also, there are some problems
+linking with `clang`, so you need to make it link with `gcc`. This one-liner should
+build and install, assuming you have numpy, cython, etc. all set up::
 
-    $ LIBRARY_PATH=/usr/local/lib/gcc/i686-apple-darwin11/4.2.1/x86_64/ make F77=gfortran
+    $ LIBRARY_PATH=/usr/local/lib/gcc LDSHARED='gcc -bundle -undefined dynamic_lookup -arch x86_64' make F77=gfortran install 
 
-Then, to get it installed into your proper python place::
-
-    $ make install


### PR DESCRIPTION
Current default numpy installation will try to use clang to link the files, but 
clang ignores the LIBRARY_PATH variable, so it can never find where you put 
gfortran.a. Instead we force it to use gcc to do the linking, by redefining the
LDSHARED command.

Updates to the Makefile should mean 'make install' builds the necessary fortran
and cython stuff first.