### PR TITLE
Add the CALL command to batch file calls.

### DIFF
--- a/make.bat
+++ b/make.bat
@@ -5,13 +5,13 @@ set f77=gfortran
 set cflags=-O3
 
 echo Compiling DASSL...
-%f77% %cflags% -c dassl/daux.f -o dassl/daux.o
-%f77% %cflags% -c dassl/ddassl.f -o dassl/ddassl.o
-%f77% %cflags% -c dassl/dlinpk.f -o dassl/dlinpk.o
-ar rcs dassl/libddassl.a dassl/daux.o dassl/ddassl.o dassl/dlinpk.o
+CALL %f77% %cflags% -c dassl/daux.f -o dassl/daux.o
+CALL %f77% %cflags% -c dassl/ddassl.f -o dassl/ddassl.o
+CALL %f77% %cflags% -c dassl/dlinpk.f -o dassl/dlinpk.o
+CALL ar rcs dassl/libddassl.a dassl/daux.o dassl/ddassl.o dassl/dlinpk.o
 
 echo Compiling PyDAS...
-python setup.py build_ext --compiler=mingw32 --inplace
+CALL python setup.py build_ext --compiler=mingw32 --inplace
 
 :end
 pause


### PR DESCRIPTION
Anaconda Python provides mingw, but the executables (gcc, gfortran, ar)
are wrapped in batch files, i.e. "gfortran.bat". Because of this, the
first command `%f77% %cflags% -c dassl/daux.f -o dassl/daux.o` will
complete successfully but the next command will not be run. In order
to execute a batch file from within a batch file and *resume*
execution in the original batch file, the CALL command must be used.
Note that in this patch, `CALL python` is not necessary in Anaconda
because by default the python executable is added to the system path.
However, adding it here does no harm, and `make.bat` will continue
to work on systems where the python executable has been wrapped in a
batch file.