### PR TITLE
Change from distutils to setuptools.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,8 +33,8 @@ import sys
 
 if __name__ == '__main__':
     
-    from distutils.core import setup
-    from distutils.extension import Extension
+    from setuptools import setup
+    from setuptools import Extension
     from Cython.Distutils import build_ext
     
     # Turn on HTML annotation file generation


### PR DESCRIPTION
NOTE: Setuptools requires Python >= 2.6. If PyDAS must support 2.5
then extra handling will be required.

By changing to setuptools, it becomes possible to build wheels via
`python setup.py build_wheel`
I have tested making wheels on Python 2.7.9.