### PR TITLE
Change from distutils to setuptools.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,8 +33,14 @@ import sys
 
 if __name__ == '__main__':
     
-    from setuptools import setup
-    from setuptools import Extension
+    # Use setuptools by default (requires Python>=2.6) if available
+    # If not available, fall back to distutils
+    # Using setuptools enables support for compiling wheels
+    try:
+        from setuptools import setup, Extension
+    except ImportError:
+        from distutils import setup, Extension
+
     from Cython.Distutils import build_ext
     
     # Turn on HTML annotation file generation

--- a/setup.py
+++ b/setup.py
@@ -33,8 +33,8 @@ import sys
 
 if __name__ == '__main__':
     
-    from distutils.core import setup
-    from distutils.extension import Extension
+    from setuptools import setup
+    from setuptools import Extension
     from Cython.Distutils import build_ext
     
     # Turn on HTML annotation file generation

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,8 @@ if __name__ == '__main__':
     try:
         from setuptools import setup, Extension
     except ImportError:
-        from distutils import setup, Extension
+        from distutils.core import setup
+        from distutils.extension import Extension
 
     from Cython.Distutils import build_ext
     


### PR DESCRIPTION
I've made a tweak that keeps distutils as an option for systems that don't/can't have setuptools. This should preserve Python<=2.5 support while also enabling the building of wheels.
